### PR TITLE
Grid Changes

### DIFF
--- a/grid.csv
+++ b/grid.csv
@@ -1,12 +1,12 @@
 Tile,Type,Number
 Start,Tax,200
 Mediterranean Ave,Property,0
-Community Chest,Chest,0
+Community Chest1,Chest,0
 Baltic Ave,Property,1
 Income Tax,Tax,-200
 Reading Railroad,Railroad,2
 Oriental Ave,Property,3
-Chance, Chance,0
+Chance1, Chance,0
 Vermont Ave,Property,4
 Conneticut Ave,Property,5
 Jail,Blank,0
@@ -16,12 +16,12 @@ States Ave,Property,8
 Virginia Ave,Property,9
 Pennsylvania Railroad,Railroad,10
 St. James Place,Property,11
-Community Chest,Chest,0
+Community Chest2,Chest,0
 Tennesse Ave,Property,12
 New York Ave,Property,13
 Free Parking,Tax,0
 Kentucky Ave,Property,14
-Chance,Chance,0
+Chance2,Chance,0
 Indiana Ave,Property,15
 Illinois Ave,Property,16
 BO Railroad,Railroad,17
@@ -32,10 +32,10 @@ Marvin Gardins,Property,21
 Go To Jail,Jail,0
 Pacific Ave,Property,22
 North Carolina Ave,Property,23
-Community Chest,Chest,0
+Community Chest3,Chest,0
 Pennsylvania Ave,Property,24
 Short Line,Railroad,25
-Chance,Chance,0
+Chance3,Chance,0
 Park Place,Property,26
 Luxury Tax,Tax,-100
 Boardwalk,Property,27

--- a/grid.csv
+++ b/grid.csv
@@ -2,40 +2,40 @@ Tile,Type,Number
 Start,Tax,200
 Mediterranean Ave,Property,0
 Community Chest,Chest,0
-Baltic Ave,Property,0
+Baltic Ave,Property,1
 Income Tax,Tax,-200
-Reading Railroad,Railroad,0
-Oriental Ave,Property,0
+Reading Railroad,Railroad,2
+Oriental Ave,Property,3
 Chance, Chance,0
-Vermont Ave,Property,0
-Conneticut Ave,Property,0
+Vermont Ave,Property,4
+Conneticut Ave,Property,5
 Jail,Blank,0
-St. Charles Place,Property,0
-Electric Company,Company,0
-States Ave,Property,0
-Virginia Ave,Property,0
-Pennsylvania Railroad,Railroad,0
-St. James Place,Property,0
+St. Charles Place,Property,6
+Electric Company,Company,7
+States Ave,Property,8
+Virginia Ave,Property,9
+Pennsylvania Railroad,Railroad,10
+St. James Place,Property,11
 Community Chest,Chest,0
-Tennesse Ave,Property,0
-New York Ave,Property,0
+Tennesse Ave,Property,12
+New York Ave,Property,13
 Free Parking,Tax,0
-Kentucky Ave,Property,0
+Kentucky Ave,Property,14
 Chance,Chance,0
-Indiana Ave,Property,0
-Illinois Ave,Property,0
-BO Railroad,Railroad,0
-Atlantic Ave,Property,0
-Ventnor Ave,Property,0
-Water Works,Company,0
-Marvin Gardins,Property,0
+Indiana Ave,Property,15
+Illinois Ave,Property,16
+BO Railroad,Railroad,17
+Atlantic Ave,Property,18
+Ventnor Ave,Property,19
+Water Works,Company,20
+Marvin Gardins,Property,21
 Go To Jail,Jail,0
-Pacific Ave,Property,0
-North Carolina Ave,Property,0
+Pacific Ave,Property,22
+North Carolina Ave,Property,23
 Community Chest,Chest,0
-Pennsylvania Ave,Property,0
-Short Line,Railroad,0
+Pennsylvania Ave,Property,24
+Short Line,Railroad,25
 Chance,Chance,0
-Park Place,Property,0
+Park Place,Property,26
 Luxury Tax,Tax,-100
-Boardwalk,Property,0
+Boardwalk,Property,27

--- a/monopoly.py
+++ b/monopoly.py
@@ -10,7 +10,7 @@ import pickle
 
 class Game:
     def __init__(self, players):
-        self.grid = []
+        self.grid = read_grid("grid.csv")
         self.players: List[Player] = players
         self.turn: int = 0
         self.properties: List[Property] = []
@@ -20,7 +20,7 @@ class Game:
         roll2 = random.randint(1,6)
         roll = roll1+roll2
         self.players[player_id].position += roll
-        self.players[player_id].position %= 22
+        self.players[player_id].position %= 40
 
     def buy(self, player_id):
         player = self.players[player_id]
@@ -41,6 +41,11 @@ class Game:
         with open("sample.json", "w") as outfile:
             json.dump(out, outfile)
 
+@dataclass
+class Tile:
+    title: str
+    tile_type: str
+    num: int
 
 @dataclass
 class Property:
@@ -78,7 +83,13 @@ class Player:
     def dict(self):
         return asdict(self)
 
-
+def read_grid(in_filename: str):
+    data = pd.read_csv(in_filename, index_col=0)
+    tiles = []
+    for title in data.index.values:
+        tiles.append(Tile(title, str(data.loc[title].iloc[0]), data.loc[title].iloc[1].item()))
+    return tiles
+    
 def read_data(in_filename: str):
     data = pd.read_csv(in_filename, index_col=0)
     properties = []


### PR DESCRIPTION
Added index numbers to each property, railroad, and company. I realized it would be very unnatural to try and store each property object inside of each Tile of the grid. Also changed the community chest and chance names so the program doesn't have a stroke trying to read them in.