### PR TITLE
Add trade function to player dataclass

### DIFF
--- a/monopoly.py
+++ b/monopoly.py
@@ -78,6 +78,13 @@ class Player:
     def dict(self):
         return asdict(self)
 
+    def trade(self, other_player, property) :
+        if property in self.properties :
+            self.properties.remove(property)
+            other_player.properties.append(property)
+        else :
+            print("You don't own that property!")
+
 
 def read_data(in_filename: str):
     data = pd.read_csv(in_filename, index_col=0)


### PR DESCRIPTION
Yes, this only takes in one property. This is to handle the lowest edge case of just giving away a property. If you want to do a trade you'd have to call it twice on both players. If we don't want the ability to give away properties then I will change it. I would also consider changing the function name to transfer.